### PR TITLE
Require all endpoints behind auth

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -4,11 +4,15 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from passlib.context import CryptContext
 from datetime import datetime, timedelta
 
+from app.config import settings
+
 
 class AuthHandler:
     security = HTTPBearer()
     pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    secret = "SECRET"
+    SECRET_KEY = settings.local_auth_secret
+    ALGORITHM = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES = 60
 
     def get_password_hash(self, password):
         return self.pwd_context.hash(password)
@@ -18,15 +22,16 @@ class AuthHandler:
 
     def encode_token(self, user_id):
         payload = {
-            "exp": datetime.utcnow() + timedelta(days=0, minutes=120),
+            "exp": datetime.utcnow()
+            + timedelta(minutes=self.ACCESS_TOKEN_EXPIRE_MINUTES),
             "iat": datetime.utcnow(),
             "sub": user_id,
         }
-        return jwt.encode(payload, self.secret, algorithm="HS256")
+        return jwt.encode(payload, self.SECRET_KEY, algorithm=self.ALGORITHM)
 
     def decode_token(self, token):
         try:
-            payload = jwt.decode(token, self.secret, algorithms=["HS256"])
+            payload = jwt.decode(token, self.SECRET_KEY, algorithms=[self.ALGORITHM])
             return payload["sub"]
         except jwt.ExpiredSignatureError:
             raise HTTPException(status_code=401, detail="Signature has expired")

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,11 @@ class Settings(BaseSettings):
     API_V2_STR: str = "/api/v2"
     admin_email: str = "devnull@ncsa.illinois.edu"
 
+    # openssl rand -hex 32
+    local_auth_secret = (
+        "47358d6ace318031e822d722c15d191ba0d3e2cc7594317514e553424ccf3e39"
+    )
+
     # exposing default ports for fronted
     CORS_ORIGINS: List[AnyHttpUrl] = [
         "http://localhost:3000",

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 import uvicorn
-from fastapi import FastAPI, APIRouter
+from fastapi import FastAPI, APIRouter, Depends
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers import (
@@ -11,6 +11,7 @@ from app.routers import (
     folders,
 )
 from app.config import settings
+from app.routers.authentication import auth_handler
 
 app = FastAPI(
     title=settings.APP_NAME, openapi_url=f"{settings.API_V2_STR}/openapi.json"
@@ -26,13 +27,31 @@ app.add_middleware(
 
 api_router = APIRouter()
 api_router.include_router(users.router, prefix="/users", tags=["users"])
-api_router.include_router(files.router, prefix="/files", tags=["files"])
-api_router.include_router(datasets.router, prefix="/datasets", tags=["datasets"])
 api_router.include_router(
-    collections.router, prefix="/collections", tags=["collections"]
+    files.router,
+    prefix="/files",
+    tags=["files"],
+    dependencies=[Depends(auth_handler.auth_wrapper)],
+)
+api_router.include_router(
+    datasets.router,
+    prefix="/datasets",
+    tags=["datasets"],
+    dependencies=[Depends(auth_handler.auth_wrapper)],
+)
+api_router.include_router(
+    collections.router,
+    prefix="/collections",
+    tags=["collections"],
+    dependencies=[Depends(auth_handler.auth_wrapper)],
 )
 api_router.include_router(authentication.router, tags=["login"])
-api_router.include_router(folders.router, prefix="/folders", tags=["folders"])
+api_router.include_router(
+    folders.router,
+    prefix="/folders",
+    tags=["folders"],
+    dependencies=[Depends(auth_handler.auth_wrapper)],
+)
 
 app.include_router(api_router, prefix=settings.API_V2_STR)
 

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,12 @@ app.add_middleware(
 )
 
 api_router = APIRouter()
-api_router.include_router(users.router, prefix="/users", tags=["users"])
+api_router.include_router(
+    users.router,
+    prefix="/users",
+    tags=["users"],
+    dependencies=[Depends(auth_handler.auth_wrapper)],
+)
 api_router.include_router(
     files.router,
     prefix="/files",
@@ -45,13 +50,13 @@ api_router.include_router(
     tags=["collections"],
     dependencies=[Depends(auth_handler.auth_wrapper)],
 )
-api_router.include_router(authentication.router, tags=["login"])
 api_router.include_router(
     folders.router,
     prefix="/folders",
     tags=["folders"],
     dependencies=[Depends(auth_handler.auth_wrapper)],
 )
+api_router.include_router(authentication.router, tags=["login"])
 
 app.include_router(api_router, prefix=settings.API_V2_STR)
 

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -68,14 +68,6 @@ async def get_datasets(
 
 @router.get("/{dataset_id}", response_model=DatasetOut)
 async def get_dataset(dataset_id: str, db: MongoClient = Depends(dependencies.get_db)):
-    # if (
-    #     dataset := await db["datasets"].find_one({"_id": ObjectId(dataset_id)})
-    # ) is not None:
-    #     if (
-    #         user := await db["users"].find_one({"_id": ObjectId(dataset["author"])})
-    #     ) is not None:
-    #         dataset["author"] = user
-    #         return Dataset.from_mongo(dataset)
     if (
         dataset := await db["datasets"].find_one({"_id": ObjectId(dataset_id)})
     ) is not None:

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -5,30 +5,32 @@ from fastapi import APIRouter, HTTPException, Depends
 from pymongo import MongoClient
 
 from app import dependencies
-from app.models.users import UserDB
+from app.models.users import UserDB, UserOut
 
 router = APIRouter()
 
 
-@router.get("", response_model=List[UserDB])
+@router.get("", response_model=List[UserOut])
 async def get_users(
     db: MongoClient = Depends(dependencies.get_db), skip: int = 0, limit: int = 2
 ):
     users = []
     for doc in await db["users"].find().skip(skip).limit(limit).to_list(length=limit):
-        users.append(doc)
+        users.append(UserOut(**doc))
     return users
 
 
-@router.get("/{user_id}", response_model=UserDB)
+@router.get("/{user_id}", response_model=UserOut)
 async def get_user(user_id: str, db: MongoClient = Depends(dependencies.get_db)):
     if (user := await db["users"].find_one({"_id": ObjectId(user_id)})) is not None:
-        return UserDB.from_mongo(user)
+        return UserOut.from_mongo(user)
     raise HTTPException(status_code=404, detail=f"User {user_id} not found")
 
 
-@router.get("/username/{name}", response_model=UserDB)
-async def get_user_by_name(name: str, db: MongoClient = Depends(dependencies.get_db)):
-    if (user := await db["users"].find_one({"name": name})) is not None:
-        return UserDB.from_mongo(user)
-    raise HTTPException(status_code=404, detail=f"User {name} not found")
+@router.get("/username/{username}", response_model=UserOut)
+async def get_user_by_name(
+    username: str, db: MongoClient = Depends(dependencies.get_db)
+):
+    if (user := await db["users"].find_one({"email": username})) is not None:
+        return UserOut.from_mongo(user)
+    raise HTTPException(status_code=404, detail=f"User {username} not found")

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,23 +1,13 @@
 from typing import List
 
 from bson import ObjectId
-from fastapi import APIRouter, Request, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends
 from pymongo import MongoClient
 
 from app import dependencies
-from app.models.users import UserDB, UserIn
-from passlib.hash import bcrypt
+from app.models.users import UserDB
 
 router = APIRouter()
-
-
-@router.post("", response_model=UserDB)
-async def save_user(userIn: UserIn, db: MongoClient = Depends(dependencies.get_db)):
-    hashed_password = bcrypt.hash(userIn.password)
-    userDB = UserDB(**userIn.dict(), hashed_password=hashed_password)
-    res = await db["users"].insert_one(userDB.to_mongo())
-    found = await db["users"].find_one({"_id": res.inserted_id})
-    return UserDB.from_mongo(found).dict(exclude={"create_at"})
 
 
 @router.get("", response_model=List[UserDB])


### PR DESCRIPTION
by adding `dependencies=[Depends(auth_handler.auth_wrapper)]` to each router, with the exception of the authentication router. Note that `user_id=Depends(auth_handler.auth_wrapper)` on individual endpoints is still required if we need to get the `user_id`.

Also moved the JWT secret key to the config file. I have it set to something to make develop setup easy, but maybe it should be in a .env and we should require it to be setup the first time someone sets up their environment.