### PR TITLE
Fixed bug with type for `mine` query param to be bool. 

### DIFF
--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -45,7 +45,7 @@ async def get_datasets(
     db: MongoClient = Depends(dependencies.get_db),
     skip: int = 0,
     limit: int = 2,
-    mine=False,
+    mine: bool = False,
 ):
     datasets = []
     if mine:


### PR DESCRIPTION
If not set it would read the parameter as a string and not match the if statement.